### PR TITLE
Accept https URLs on node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jusbrasil/sixpack-client",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "JS client for SeatGeek's Sixpack AB testing framework.",
   "main": "sixpack.js",
   "scripts": {

--- a/sixpack.js
+++ b/sixpack.js
@@ -197,7 +197,8 @@
             script.async = true;
             document.body.appendChild(script);
         } else {
-            var http = require('http');
+            const httpModule = url.startsWith('https') ? 'https' : 'http';
+            var http = require(httpModule);
             var req = http.get(url, { headers: { 'Cookie': cookie } }, function(res) {
                 var body = "";
                 res.on('data', function(chunk) {


### PR DESCRIPTION
When trying to use this client in server-side (https://github.com/jusbrasil/polaris/pull/280) I see the following error:
```
TypeError [ERR_INVALID_PROTOCOL] [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
    at new ClientRequest (_http_client.js:153:11)
    at request (http.js:46:10)
    at Object.get (http.js:50:15)
    at _request (/home/francisco/programs/git/github.com/jusbrasil/polaris/node_modules/@jusbrasil/sixpack-client/sixpack.js:202:28)
    at sixpack.Session.participate (/home/francisco/programs/git/github.com/jusbrasil/polaris/node_modules/@jusbrasil/sixpack-client/sixpack.js:124:20)
```

This PR fixes it.