### PR TITLE
Allow forced alternative with participating value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jusbrasil/sixpack-client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "JS client for SeatGeek's Sixpack AB testing framework.",
   "main": "sixpack.js",
   "scripts": {

--- a/sixpack.js
+++ b/sixpack.js
@@ -112,8 +112,8 @@
             if (traffic_fraction !== null && !isNaN(traffic_fraction)) {
                 params.traffic_fraction = traffic_fraction;
             }
-            if (force != null && _in_array(alternatives, force)) {
-                return callback(null, {"status": "ok", "alternative": {"name": force}, "experiment": {"version": 0, "name": experiment_name}, "client_id": this.client_id});
+            if (force != null) {
+                return callback(null, {"status": "ok", "alternative": {"name": force}, "experiment": {"version": 0, "name": experiment_name}, "client_id": this.client_id, "participating": true});
             }
             if (this.ip_address) {
                 params.ip_address = this.ip_address;
@@ -244,15 +244,6 @@
             endpoint += '?' + query_string.join('&');
         }
         return endpoint;
-    };
-
-    var _in_array = function(a, v) {
-        for(var i = 0; i < a.length; i++) {
-            if(a[i] === v) {
-                return true;
-            }
-        }
-        return false;
     };
 
     // export module for node or environments with module loaders, such as webpack

--- a/test/sixpack-test.js
+++ b/test/sixpack-test.js
@@ -65,27 +65,40 @@ describe("Sixpack in node", function () {
         });
     });
 
-    it("should return forced alternative for participate with force", function (done) {
+    it("should return forced alternative with participating for participate with force", function (done) {
         session.participate("show-bieber", ["trolled", "not-trolled"], "trolled", function(err, resp) {
             if (err) throw err;
             expect(resp.alternative.name).to.equal("trolled");
+            expect(resp.participating).to.equal(true);
             session.participate("show-bieber", ["trolled", "not-trolled"], "not-trolled", function(err, resp) {
                 if (err) throw err;
                 expect(resp.alternative.name).to.equal("not-trolled");
+                expect(resp.participating).to.equal(true);
                 done();
             });
         });
     });
 
-    it("should return ok and forced alternative for participate with traffic_fraction and force", function (done) {
+    it("should return forced alternative with participating for participate with force even if outside alternatives", function (done) {
+        session.participate("show-bieber", ["trolled", "not-trolled"], "whatever", function(err, resp) {
+            if (err) throw err;
+            expect(resp.alternative.name).to.equal("whatever");
+            expect(resp.participating).to.equal(true);
+            done();
+        });
+    });
+
+    it("should return ok and forced alternative with participating for participate with traffic_fraction and force", function (done) {
         session.participate("show-bieber-fraction", ["trolled", "not-trolled"], 0.1, "trolled", function(err, resp) {
             if (err) throw err;
             expect(resp.status).to.equal("ok");
             expect(resp.alternative.name).to.equal("trolled");
+            expect(resp.participating).to.equal(true);
             session.participate("show-bieber-fraction", ["trolled", "not-trolled"], 0.1, "not-trolled", function(err, resp) {
                 if (err) throw err;
                 expect(resp.status).to.equal("ok");
                 expect(resp.alternative.name).to.equal("not-trolled");
+                expect(resp.participating).to.equal(true);
                 done();
             });
         });


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**
The current experiments API returns a [`participating` value](https://github.com/jusbrasil/argos#get-participate) on its responses, but when the participation is forced via the `sixpack-force` URL param this client currently skips this field. This PR will add this field to forced participations.

**References:**
https://jus.atlassian.net/browse/MON-30

**Notes:**
n/a