### PR TITLE
Fix const and require

### DIFF
--- a/sixpack.js
+++ b/sixpack.js
@@ -197,7 +197,8 @@
             script.async = true;
             document.body.appendChild(script);
         } else {
-            var http = url.startsWith('https') ? require('https') : require('http');
+            var httpModule = url.startsWith('https') ? 'https' : 'http';
+            var http = eval('require')(httpModule);
             var req = http.get(url, { headers: { 'Cookie': cookie } }, function(res) {
                 var body = "";
                 res.on('data', function(chunk) {

--- a/sixpack.js
+++ b/sixpack.js
@@ -198,7 +198,7 @@
             document.body.appendChild(script);
         } else {
             var httpModule = url.startsWith('https') ? 'https' : 'http';
-            var http = eval('require')(httpModule);
+            var http = eval('require')(httpModule); // using eval to skip webpack bundling and warnings
             var req = http.get(url, { headers: { 'Cookie': cookie } }, function(res) {
                 var body = "";
                 res.on('data', function(chunk) {

--- a/sixpack.js
+++ b/sixpack.js
@@ -197,8 +197,7 @@
             script.async = true;
             document.body.appendChild(script);
         } else {
-            const httpModule = url.startsWith('https') ? 'https' : 'http';
-            var http = require(httpModule);
+            var http = url.startsWith('https') ? require('https') : require('http');
             var req = http.get(url, { headers: { 'Cookie': cookie } }, function(res) {
                 var body = "";
                 res.on('data', function(chunk) {


### PR DESCRIPTION
Use of `const` breaks JS parsing in old browsers.
Use `eval('require')` to skip Webpack, when using `require('http')` it stores the modules inside the bundle and using dynamic require it outputs warnings.