### PR TITLE
feat: add options object as param http.get call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jusbrasil/sixpack-client",
-  "version": "2.3.4",
+  "version": "2.3.5-beta.3",
   "description": "JS client for SeatGeek's Sixpack AB testing framework.",
   "main": "sixpack.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jusbrasil/sixpack-client",
-  "version": "2.3.5-beta.3",
+  "version": "2.3.5-beta.4",
   "description": "JS client for SeatGeek's Sixpack AB testing framework.",
   "main": "sixpack.js",
   "scripts": {

--- a/sixpack.js
+++ b/sixpack.js
@@ -213,7 +213,6 @@
 
                     if (res.statusCode < 500) {
                         try {
-                            console.log("body: ", body)
                             data = JSON.parse(body);
                         } catch (err) {
                             console.error(err);

--- a/sixpack.js
+++ b/sixpack.js
@@ -199,7 +199,11 @@
         } else {
             var httpModule = url.startsWith('https') ? 'https' : 'http';
             var http = eval('require')(httpModule); // using eval to skip webpack bundling and warnings
-            var req = http.get(url, { headers: { 'Cookie': cookie } }, function(res) {
+
+            const parsedUrl = eval('require')('url').parse(url);
+            const options = { ...parsedUrl, headers: { Cookie: cookie } };
+
+            var req = http.get(options, function(res) {
                 var body = "";
                 res.on('data', function(chunk) {
                     return body += chunk;
@@ -209,6 +213,7 @@
 
                     if (res.statusCode < 500) {
                         try {
+                            console.log("body: ", body)
                             data = JSON.parse(body);
                         } catch (err) {
                             console.error(err);

--- a/sixpack.js
+++ b/sixpack.js
@@ -200,8 +200,18 @@
             var httpModule = url.startsWith('https') ? 'https' : 'http';
             var http = eval('require')(httpModule); // using eval to skip webpack bundling and warnings
 
-            const parsedUrl = eval('require')('url').parse(url);
-            const options = { ...parsedUrl, headers: { Cookie: cookie } };
+            const parsedUrl = new URL(url);
+            const options = {
+                protocol: parsedUrl.protocol,
+                host: parsedUrl.host,
+                port: parsedUrl.port,
+                hostname: parsedUrl.hostname,
+                search: parsedUrl.search,
+                pathname: parsedUrl.pathname,
+                path: parsedUrl.pathname + parsedUrl.search, 
+                href: parsedUrl.href,
+                headers: { Cookie: cookie }
+            }
 
             var req = http.get(options, function(res) {
                 var body = "";

--- a/sixpack.js
+++ b/sixpack.js
@@ -202,14 +202,9 @@
 
             const parsedUrl = new URL(url);
             const options = {
-                protocol: parsedUrl.protocol,
-                host: parsedUrl.host,
                 port: parsedUrl.port,
                 hostname: parsedUrl.hostname,
-                search: parsedUrl.search,
-                pathname: parsedUrl.pathname,
                 path: parsedUrl.pathname + parsedUrl.search, 
-                href: parsedUrl.href,
                 headers: { Cookie: cookie }
             }
 


### PR DESCRIPTION
We're fixing http requests when an internal url is defined.


Reference:
https://jusbrasil.slack.com/archives/C013E4XTTC2/p1625057288476300