### PR TITLE
feat: url parse on http get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 ENV wdir /app
 RUN mkdir -p ${wdir}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Run the tests with:
 npm run test
 ```
 
+### Running tests outside of docker container
+We can also run tests outside a docker container. To do that:
+
+Run server apps:
+```sh
+docker-compose up -d && docker-compose logs -f -t
+```
+
+Now we can run tests using dockerized environment by running:
+```sh
+SIXPACK_BASE_URL=http://localhost:8000 yarn test:mocha
+```
+
+
 ### Sixpack server location
 
 The tests assume the [sixpack-server](https://github.com/seatgeek/sixpack) server is running and located at `http://localhost:5000`. To use a different location, _e.g._ for a Docker [container](https://github.com/ainoya/docker-sixpack), run tests with the following pattern:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
   server:
     image: leogamas/sixpack:v0.1
     command: "sixpack.server:start"
+    ports:
+      - "8000:8000"
     expose:
       - 8000
     environment:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.3.4",
   "description": "JS client for SeatGeek's Sixpack AB testing framework.",
   "main": "sixpack.js",
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "test": "docker-compose up --build --abort-on-container-exit --exit-code-from client",
     "test:mocha": "mocha --globals document,window"

--- a/sixpack.js
+++ b/sixpack.js
@@ -202,6 +202,7 @@
 
             var parsedUrl = new URL(url);
             var options = {
+                protocol: parsedUrl.protocol,
                 port: parsedUrl.port,
                 hostname: parsedUrl.hostname,
                 path: parsedUrl.pathname + parsedUrl.search, 

--- a/sixpack.js
+++ b/sixpack.js
@@ -199,7 +199,15 @@
         } else {
             var httpModule = url.startsWith('https') ? 'https' : 'http';
             var http = eval('require')(httpModule); // using eval to skip webpack bundling and warnings
-            var req = http.get(url, { headers: { 'Cookie': cookie } }, function(res) {
+
+            var parsedUrl = new URL(url);
+            var options = {
+                port: parsedUrl.port,
+                hostname: parsedUrl.hostname,
+                path: parsedUrl.pathname + parsedUrl.search, 
+                headers: { Cookie: cookie }
+            }
+            var req = http.get(options, function(res) {
                 var body = "";
                 res.on('data', function(chunk) {
                     return body += chunk;

--- a/test/sixpack-test.js
+++ b/test/sixpack-test.js
@@ -35,9 +35,9 @@ describe("Sixpack in node", function () {
         var originalGet = http.get;
         var receivedHeaders;
         try {
-            http.get = (url, options, callback) => {
+            http.get = (options, callback) => {
                 receivedHeaders = options.headers;
-                return originalGet(url, options, callback);
+                return originalGet(options, callback);
             }
             session.participate("show-bieber", ["trolled", "not-trolled"], function(err, resp) {
                 if (err) throw err;


### PR DESCRIPTION
This's the first step to split `sixpack-client` in `browser` and `server` different libs.
- We add URL parsing before http GET request.
- We update node version (minor)
- We add docker-compose port mapping to let us run tests outside of docker container.

PS:
We don't need to generate new version of this change, because we already have beta version with URL parsing feat running on `deadpool`.

**References**
https://github.com/orgs/jusbrasil/projects/39#card-64695354